### PR TITLE
Remove auth mode

### DIFF
--- a/draft-ietf-jose-hpke-encrypt.md
+++ b/draft-ietf-jose-hpke-encrypt.md
@@ -148,7 +148,7 @@ The HPKE KEM, KDF, and AEAD used depend on the JOSE-HPKE algorithm used.
 
 HPKE supports several modes, which are described in Table 1 of {{RFC9180}}.
 
-In JOSE-HPKE, only the "base_mode" is used.
+In JOSE-HPKE, the "base_mode" and "mode_psk" are determined by the presence of the JOSE Header parameter "psk_id"
 
 JWE supports different serializations, including Compact JWE Serialization as described in Section 3.1 of {{RFC7516}}, General JWE JSON Serialization as described in Section 3.2 of {{RFC7516}}.
 

--- a/draft-ietf-jose-hpke-encrypt.md
+++ b/draft-ietf-jose-hpke-encrypt.md
@@ -273,6 +273,7 @@ In HPKE JWE Key Encryption:
 - When all recipients use the same HPKE algorithm to secure the Content Encryption Key, the JWE Protected Header SHOULD contain "alg".
 Otherwise, the JWE Protected Header (and JWE Shared Unprotected Header) MUST NOT contain "alg".
 - JOSE Header parameter "alg" MUST be a JOSE-HPKE algorithm.
+- JOSE Header parameter "psk_id" MAY be present.
 - JOSE Header parameter "ek" MUST be present and contain base64url-encoded HPKE encapsulated key.
 - Recipient JWE Encrypted Key MUST be the ciphertext from HPKE Encryption.
 - The HPKE Setup info parameter MUST be set to an empty string.

--- a/draft-ietf-jose-hpke-encrypt.md
+++ b/draft-ietf-jose-hpke-encrypt.md
@@ -547,7 +547,13 @@ The following entries are added to the "JSON Web Key Parameters" registry:
 - Header Parameter Usage Location(s): JWE
 - Change Controller: IETF
 - Specification Document(s):   RFCXXXX
+### psk_id
 
+- Header Parameter Name: "psk_id"
+- Header Parameter Description: A key identifier (kid) for the pre-shared key as defined in { Section 5.1.2 of RFC9180 }
+- Header Parameter Usage Location(s): JWE
+- Change Controller: IETF
+- Specification Document(s):   RFCXXXX
 --- back
 
 # Keys Used in Examples

--- a/draft-ietf-jose-hpke-encrypt.md
+++ b/draft-ietf-jose-hpke-encrypt.md
@@ -432,9 +432,6 @@ Implementers are advised to review Section 3.2 of {{RFC8725}}, which comments on
 This is guidance is relevant to both Key Encryption and Integrated Encryption.
 When using Key Encryption, the strength of the content encryption algorithm should not be significantly different from the strengh of the Key Encryption algorithms used.
 
-## HPKE Mode Support
-
-TODO: Summarize that only base and psk mode are supported
 #  IANA Considerations {#IANA}
 
 This document adds entries to {{JOSE-IANA}}.

--- a/draft-ietf-jose-hpke-encrypt.md
+++ b/draft-ietf-jose-hpke-encrypt.md
@@ -429,18 +429,9 @@ Implementers are advised to review Section 3.2 of {{RFC8725}}, which comments on
 This is guidance is relevant to both Key Encryption and Integrated Encryption.
 When using Key Encryption, the strength of the content encryption algorithm should not be significantly different from the strengh of the Key Encryption algorithms used.
 
-## Authenticated KEM
+## HPKE Mode Support
 
-Authenticated KEM is not supported in JOSE HPKE for the following reasons:
-
-1. Authenticated KEMs provide authentication at the KEM level, which has different implications depending on whether they are used for key
-encryption or integrated encryption. In integrated encryption, the KEM operations directly secure the message plaintext. In key encryption,
-the KEM operations secure the content encryption key. Using authenticated KEMs for key encryption does not provide meaningful security
-benefits and will create a false sense of data origin authentication.
-
-2. The PQ/T Hybrid KEM in HPKE is not an authenticated KEM and can only be used with HPKE Base mode. Similarly, PQ KEMs in HPKE are not
-authenticated KEMs, making them incompatible with an authenticated KEM approach.
-
+TODO: Summarize that only base and psk mode are supported
 #  IANA Considerations {#IANA}
 
 This document adds entries to {{JOSE-IANA}}.

--- a/draft-ietf-jose-hpke-encrypt.md
+++ b/draft-ietf-jose-hpke-encrypt.md
@@ -148,7 +148,8 @@ The HPKE KEM, KDF, and AEAD used depend on the JOSE-HPKE algorithm used.
 
 HPKE supports several modes, which are described in Table 1 of {{RFC9180}}.
 
-In JOSE-HPKE, the "base_mode" and "mode_psk" are determined by the presence of the JOSE Header parameter "psk_id"
+In JOSE-HPKE, only "mode_base" and "mode_psk" are supported.
+When "psk_id" JOSE Header parameter is present the mode is "mode_psk", otherwise the mode is "mode_base".
 
 JWE supports different serializations, including Compact JWE Serialization as described in Section 3.1 of {{RFC7516}}, General JWE JSON Serialization as described in Section 3.2 of {{RFC7516}}.
 

--- a/draft-ietf-jose-hpke-encrypt.md
+++ b/draft-ietf-jose-hpke-encrypt.md
@@ -190,6 +190,7 @@ In HPKE JWE Integrated Encryption:
 - The protected header MUST contain an "alg" that is JOSE-HPKE algorithm.
 - The protected header MUST contain an "enc" with value "dir". This is an explicit exception to requirement in Section 4.1.2 of {{RFC7516}} that
 "enc" must be an AEAD algorithm. This is appropriate, as HPKE will perform plaintext encryption.
+- The protected header parameters "psk_id" MAY be present.
 - The protected header parameter "ek" MUST NOT be present.
 - There MUST be exactly one recipient.
 - The JWE Encrypted Key MUST be encapsulated key as defined in Section 5.1.1 of {{RFC9180}}.

--- a/draft-ietf-jose-hpke-encrypt.md
+++ b/draft-ietf-jose-hpke-encrypt.md
@@ -603,7 +603,7 @@ for their contributions to the specification.
 # Document History
 {: numbered="false"}
 
--07
+-08
 
 * Remove auth mode and auth_kid from the specification.
 

--- a/draft-ietf-jose-hpke-encrypt.md
+++ b/draft-ietf-jose-hpke-encrypt.md
@@ -100,8 +100,7 @@ public key encryption of arbitrary-sized plaintexts for a recipient public key.
 
 HPKE works for any combination of an asymmetric key encapsulation mechanism (KEM),
 key derivation function (KDF), and authenticated encryption with additional data
-(AEAD) function. Authentication for HPKE in JOSE is provided by
-JOSE-native security mechanisms or by one of the authenticated variants of HPKE.
+(AEAD) function.
 
 This document defines the use of the HPKE with JOSE.
 
@@ -149,8 +148,8 @@ The HPKE KEM, KDF, and AEAD used depend on the JOSE-HPKE algorithm used.
 
 HPKE supports several modes, which are described in Table 1 of {{RFC9180}}.
 
-In JOSE-HPKE, the HPKE mode used (e.g, "mode_base" or "mode_auth_psk") is determined
-by the presence of the JOSE Header parameters "psk_id" and "auth_kid".
+In JOSE-HPKE, the HPKE mode used (e.g, "mode_base" or "mode_psk") is determined
+by the presence of the JOSE Header parameters "psk_id".
 
 JWE supports different serializations, including Compact JWE Serialization as described in Section 3.1 of {{RFC7516}}, General JWE JSON Serialization as described in Section 3.2 of {{RFC7516}}.
 
@@ -192,7 +191,7 @@ In HPKE JWE Integrated Encryption:
 - The protected header MUST contain an "alg" that is JOSE-HPKE algorithm.
 - The protected header MUST contain an "enc" with value "dir". This is an explicit exception to requirement in Section 4.1.2 of {{RFC7516}} that
 "enc" must be an AEAD algorithm. This is appropriate, as HPKE will perform plaintext encryption.
-- The protected header parameters "psk_id" and "auth_kid" MAY be present.
+- The protected header parameters "psk_id" MAY be present.
 - The protected header parameter "ek" MUST NOT be present.
 - There MUST be exactly one recipient.
 - The JWE Encrypted Key MUST be encapsulated key as defined in Section 5.1.1 of {{RFC9180}}.
@@ -256,8 +255,7 @@ After verification:
     "alg": "HPKE-0",
     "enc": "dir",
     "kid": "urn:ietf:params:oauth:jwk-thumbprint:sha-256:S6AXfdU_6Yfzvu0KDDJb0sFuwnIWPk6LMTErYhPb32s",
-    "psk_id": "our-pre-shared-key-id",
-    "auth_kid": "urn:ietf:params:oauth:jwk-thumbprint:sha-256:S6AXfdU_6Yfzvu0KDDJb0sFuwnIWPk6LMTErYhPb32s"
+    "psk_id": "our-pre-shared-key-id"
   },
   "plaintext": "🖤 this plaintext!",
   "additionalAuthenticatedData": "🏴‍☠️ beware the aad!"
@@ -279,7 +277,6 @@ In HPKE JWE Key Encryption:
 Otherwise, the JWE Protected Header (and JWE Shared Unprotected Header) MUST NOT contain "alg".
 - JOSE Header parameter "alg" MUST be a JOSE-HPKE algorithm.
 - JOSE Header parameter "psk_id" MAY be present.
-- JOSE Header parameter "auth_kid" SHOULD NOT be present.
 - JOSE Header parameter "ek" MUST be present and contain base64url-encoded HPKE encapsulated key.
 - Recipient JWE Encrypted Key MUST be the ciphertext from HPKE Encryption.
 - The HPKE Setup info parameter MUST be set to an empty string.
@@ -319,7 +316,6 @@ For example:
         "alg": "HPKE-0",
         "kid": "urn:ietf:params:oauth:jwk-thumbprint:sha-256:S6AXfdU_6Yfzvu0KDDJb0sFuwnIWPk6LMTErYhPb32s",
         "psk_id": "our-pre-shared-key-id",
-        "auth_kid": "urn:ietf:params:oauth:jwk-thumbprint:sha-256:S6AXfdU_6Yfzvu0KDDJb0sFuwnIWPk6LMTErYhPb32s",
         "ek": "BI41YDnhTTI6jSd7T62rLwzCCt_tBqN5LFooiZ7eXJsh01O0-h-BQ6JToKX9UXDw_3ylbXTiYWmPXl2fNmr4BeQ"
       }
     }
@@ -340,7 +336,6 @@ After verification:
     "enc": "dir",
     "kid": "urn:ietf:params:oauth:jwk-thumbprint:sha-256:S6AXfdU_6Yfzvu0KDDJb0sFuwnIWPk6LMTErYhPb32s",
     "psk_id": "our-pre-shared-key-id",
-    "auth_kid": "urn:ietf:params:oauth:jwk-thumbprint:sha-256:S6AXfdU_6Yfzvu0KDDJb0sFuwnIWPk6LMTErYhPb32s",
     "ek": "BI41YDnhTTI6jSd7T62rLwzCCt_tBqN5LFooiZ7eXJsh01O0-h-BQ6JToKX9UXDw_3ylbXTiYWmPXl2fNmr4BeQ"
   },
   "additionalAuthenticatedData": "paul atreides"
@@ -469,12 +464,8 @@ The "HPKE Mode" is described in Table 1 of {{RFC9180}}:
 which only enables encryption to the holder of a given KEM private key.
 - "PSK" refers to "mode_psk", described in Section 5.1.2 of {{RFC9180}},
 which authenticates using a pre-shared key.
-- "Auth" refers to "mode_auth", described in Section 5.1.3 of {{RFC9180}},
-which authenticates using an asymmetric key.
-- "Auth_Psk" refers to "mode_auth_psk", described in Section 5.1.4 of {{RFC9180}},
-which authenticates using both a PSK and an asymmetric key.
 
-The mode used is specified by presence or absence of header parameters "psk_id" and "auth_kid".
+The mode used is specified by presence or absence of header parameters "psk_id".
 
 ## JSON Web Signature and Encryption Algorithms
 
@@ -570,14 +561,6 @@ The following entries are added to the "JSON Web Key Parameters" registry:
 - Change Controller: IETF
 - Specification Document(s):   RFCXXXX
 
-### auth_kid
-
-- Header Parameter Name: "auth_kid"
-- Header Parameter Description: A key identifier (kid) for the asymmetric key as defined in { Section 5.1.3 of RFC9180 }
-- Header Parameter Usage Location(s): JWE
-- Change Controller: IETF
-- Specification Document(s):   RFCXXXX
-
 --- back
 
 # Keys Used in Examples
@@ -619,6 +602,10 @@ for their contributions to the specification.
 
 # Document History
 {: numbered="false"}
+
+-07
+
+* Remove auth mode and auth_kid from the specification.
 
 -05
 

--- a/draft-ietf-jose-hpke-encrypt.md
+++ b/draft-ietf-jose-hpke-encrypt.md
@@ -438,7 +438,8 @@ encryption or integrated encryption. In integrated encryption, the KEM operation
 the KEM operations secure the content encryption key. Using authenticated KEMs for key encryption does not provide meaningful security
 benefits and will create a false sense of data origin authentication.
 
-2. The PQ/T Hybrid KEM in HPKE is not an authenticated KEM and can only be used with HPKE Base mode. Similarly, PQ KEMs in HPKE are not authenticated KEMs, making them incompatible with an authenticated KEM approach. 
+2. The PQ/T Hybrid KEM in HPKE is not an authenticated KEM and can only be used with HPKE Base mode. Similarly, PQ KEMs in HPKE are not
+authenticated KEMs, making them incompatible with an authenticated KEM approach.
 
 #  IANA Considerations {#IANA}
 


### PR DESCRIPTION
This PR removes auth mode support from this draft.
This is done based on discussions at IETF 122, to align with future work on HPKE.