### PR TITLE
Clarify protected header

### DIFF
--- a/draft-ietf-jose-hpke-encrypt.md
+++ b/draft-ietf-jose-hpke-encrypt.md
@@ -266,7 +266,7 @@ After verification:
 Recipients using JOSE-HPKE can be added alongside other recpients (e.g., `ECDH-ES+A128KW` or `RSA-OAEP-384`), as HPKE is used to encrypt the
 Content Encryption Key, which is then processed as specified in JWE.
 
-The use of the content encryption protected header encoding remains consistent with existing JWE formatting rules.
+The encoding of the protected header encoding remains consistent with existing JWE formatting rules.
 
 In HPKE JWE Key Encryption:
 

--- a/draft-ietf-jose-hpke-encrypt.md
+++ b/draft-ietf-jose-hpke-encrypt.md
@@ -595,6 +595,7 @@ for their contributions to the specification.
 -08
 
 * Remove auth mode and auth_kid from the specification.
+* HPKE AAD for JOSE HPKE Key Encryption is now empty.
 
 -05
 

--- a/draft-ietf-jose-hpke-encrypt.md
+++ b/draft-ietf-jose-hpke-encrypt.md
@@ -266,8 +266,7 @@ After verification:
 Recipients using JOSE-HPKE can be added alongside other recpients (e.g., `ECDH-ES+A128KW` or `RSA-OAEP-384`), as HPKE is used to encrypt the
 Content Encryption Key, which is then processed as specified in JWE.
 
-The protected header used in content encryption is passed to HPKE as Additional Authenticated Data. The protected header encoding remains consistent
-with existing JWE formatting rules.
+The use of the content encryption protected header encoding remains consistent with existing JWE formatting rules.
 
 In HPKE JWE Key Encryption:
 

--- a/draft-ietf-jose-hpke-encrypt.md
+++ b/draft-ietf-jose-hpke-encrypt.md
@@ -278,6 +278,7 @@ Otherwise, the JWE Protected Header (and JWE Shared Unprotected Header) MUST NOT
 - JOSE Header parameter "ek" MUST be present and contain base64url-encoded HPKE encapsulated key.
 - Recipient JWE Encrypted Key MUST be the ciphertext from HPKE Encryption.
 - The HPKE Setup info parameter MUST be set to an empty string.
+- The HPKE AAD parameter MUST be set to the empty string.
 - THE HPKE plaintext MUST be set to the CEK.
 
 The processing of "enc", "iv", "tag", "aad", and "ciphertext" is already defined in {{RFC7516}}. Implementations should follow the existing


### PR DESCRIPTION
There was confusion over what parameters are required for HPKE when using HPKE JOSE Key Encryption.
This PR clarifies that HPKE AAD is empty for key encryption.