### PR TITLE
cleanup examples and tables

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -34,11 +34,10 @@ jobs:
         path: |
           .refcache
           .venv
-          .gems
           node_modules
           .targets.mk
-        key: i-d-${{ steps.setup.outputs.date }}
-        restore-keys: i-d-
+        key: i-d-nogems-${{ steps.setup.outputs.date }}
+        restore-keys: i-d-nogems-
 
     - name: "Build Drafts"
       uses: martinthomson/i-d-template@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,11 +37,10 @@ jobs:
         path: |
           .refcache
           .venv
-          .gems
           node_modules
           .targets.mk
-        key: i-d-${{ steps.setup.outputs.date }}
-        restore-keys: i-d-
+        key: i-d-nogems-${{ steps.setup.outputs.date }}
+        restore-keys: i-d-nogems-
 
     - name: "Build Drafts"
       uses: martinthomson/i-d-template@v1

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'kramdown-rfc',
+    git: 'https://github.com/panva/kramdown-rfc.git',
+    branch: 'extended-include-fold-smart-left'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 LIBDIR := lib
+BUNDLE_PATH := $(CURDIR)/.gems
+kramdown-rfc := env BUNDLE_GEMFILE=$(CURDIR)/Gemfile \
+    BUNDLE_PATH=$(BUNDLE_PATH) bundle exec kramdown-rfc
 include $(LIBDIR)/main.mk
 
 $(LIBDIR)/main.mk:

--- a/draft-ietf-jose-hpke-encrypt.md
+++ b/draft-ietf-jose-hpke-encrypt.md
@@ -81,6 +81,7 @@ normative:
   RFC8937:
 
 informative:
+  RFC8792:
   RFC7515:
   RFC7518:
   RFC9864:
@@ -271,50 +272,32 @@ When using Integrated Encryption with HPKE:
 The following JWE algorithms using HPKE are defined for use with
 Integrated Encryption as the Key Management Mode:
 
-~~~
-+--------+------------------+-------------+------------------+
-| "alg"  | HPKE KEM         | HPKE KDF    | HPKE AEAD        |
-+--------+------------------+-------------+------------------+
-| HPKE-0 | DHKEM(P-256,     | HKDF-SHA256 | AES-128-GCM      |
-|        |   HKDF-SHA256)   |             |                  |
-| HPKE-1 | DHKEM(P-384,     | HKDF-SHA384 | AES-256-GCM      |
-|        |   HKDF-SHA384)   |             |                  |
-| HPKE-2 | DHKEM(P-521,     | HKDF-SHA512 | AES-256-GCM      |
-|        |   HKDF-SHA512)   |             |                  |
-| HPKE-3 | DHKEM(X25519,    | HKDF-SHA256 | AES-128-GCM      |
-|        |   HKDF-SHA256)   |             |                  |
-| HPKE-4 | DHKEM(X25519,    | HKDF-SHA256 | ChaCha20Poly1305 |
-|        |   HKDF-SHA256)   |             |                  |
-| HPKE-5 | DHKEM(X448,      | HKDF-SHA512 | AES-256-GCM      |
-|        |   HKDF-SHA512)   |             |                  |
-| HPKE-6 | DHKEM(X448,      | HKDF-SHA512 | ChaCha20Poly1305 |
-|        |   HKDF-SHA512)   |             |                  |
-| HPKE-7 | DHKEM(P-256,     | HKDF-SHA256 | AES-256-GCM      |
-|        |   HKDF-SHA256)   |             |                  |
-+--------+------------------+-------------+------------------+
-~~~
+| "alg"  | HPKE KEM                   | HPKE KDF    | HPKE AEAD        |
+| ------ | -------------------------- | ----------- | ---------------- |
+| HPKE-0 | DHKEM(P-256, HKDF-SHA256)  | HKDF-SHA256 | AES-128-GCM      |
+| HPKE-1 | DHKEM(P-384, HKDF-SHA384)  | HKDF-SHA384 | AES-256-GCM      |
+| HPKE-2 | DHKEM(P-521, HKDF-SHA512)  | HKDF-SHA512 | AES-256-GCM      |
+| HPKE-3 | DHKEM(X25519, HKDF-SHA256) | HKDF-SHA256 | AES-128-GCM      |
+| HPKE-4 | DHKEM(X25519, HKDF-SHA256) | HKDF-SHA256 | ChaCha20Poly1305 |
+| HPKE-5 | DHKEM(X448, HKDF-SHA512)   | HKDF-SHA512 | AES-256-GCM      |
+| HPKE-6 | DHKEM(X448, HKDF-SHA512)   | HKDF-SHA512 | ChaCha20Poly1305 |
+| HPKE-7 | DHKEM(P-256, HKDF-SHA256)  | HKDF-SHA256 | AES-256-GCM      |
 {: #ciphersuite-int-algs title="Algorithms using HPKE for Integrated Encryption"}
 
 The HPKE KEM, KDF, and AEAD values are chosen from the IANA HPKE registry {{IANA.HPKE}}.
+
+Long lines in the JWE and JWK examples in this document are folded using the
+single backslash strategy from {{RFC8792}}. Before using a folded example,
+remove the RFC 8792 header and unfold the lines according to that strategy.
 
 ## JWE Compact Serialization Example {#compact-example}
 
 Below is an example of a JWE using the Compact Serialization and Integrated Encryption with HPKE:
 
 ~~~
-eyJhbGciOiJIUEtFLTAiLCJraWQiOiJ5Q25mYm1ZTVpjV3JLRHRfRGpOZWJS
-Q0IxdnhWb3F2NHVtSjRXSzhSWWprIn0.BLAJX8adrFsDKaoJAc3iy2dq-6jE
-H3Uv-bSgqIoDeREqpWglMoTS67XsXere1ZYxiQKEFU6MbWe8O7vmdlSmcUk..
-NcN9ew5aijn8W7piLVRU8r2cOP0JKqxOF4RllVsJM4qsAfVXW5Ka6so9zdUmX
-XNOXyCEk0wV_s8ICAnD4LbRa5TkhTeuhijIfAt9bQ2fMLOeyed3WyArs8yaMra
-a9Zbh4i6SaHunM7jU_xoz_N2WbykSOSySmCO49H4mP3jLW9L_TYQfeVfYsrB8
-clqokZ8h-3eQGNwmOPtkjWdpAfaHUsp4-HC9nRd6yrTU6mV65Nn2iYynu3Xkg
-y2Lm-kQKDavIEW3PBpEeiw6mtPJE9o8sT-0lZ9kpWtqog2XbNGEfjSOjujvNe
-1b0g4-FdNFMFO_fo0rxe902W1pGT7znv4Q-xBkIydK4ZwjiFN6dAXutnococ3
-7A0Hr5esPLwHRTTrBFw.
+eyJhbGciOiJIUEtFLTAiLCJraWQiOiJ5Q25mYm1ZTVpjV3JLRHRfRGpOZWJSQ0IxdnhWb3F2NHVtSjRXSzhSWWprIn0.BLAJX8adrFsDKaoJAc3iy2dq-6jEH3Uv-bSgqIoDeREqpWglMoTS67XsXere1ZYxiQKEFU6MbWe8O7vmdlSmcUk..NcN9ew5aijn8W7piLVRU8r2cOP0JKqxOF4RllVsJM4qsAfVXW5Ka6so9zdUmXXNOXyCEk0wV_s8ICAnD4LbRa5TkhTeuhijIfAt9bQ2fMLOeyed3WyArs8yaMraa9Zbh4i6SaHunM7jU_xoz_N2WbykSOSySmCO49H4mP3jLW9L_TYQfeVfYsrB8clqokZ8h-3eQGNwmOPtkjWdpAfaHUsp4-HC9nRd6yrTU6mV65Nn2iYynu3Xkgy2Lm-kQKDavIEW3PBpEeiw6mtPJE9o8sT-0lZ9kpWtqog2XbNGEfjSOjujvNe1b0g4-FdNFMFO_fo0rxe902W1pGT7znv4Q-xBkIydK4ZwjiFN6dAXutnococ37A0Hr5esPLwHRTTrBFw.
 ~~~
-
-Note: Line breaks are for display purposes only.
+{: post="fold69hardleftdry"}
 
 The key used for this example is in {{int-key}}.
 
@@ -322,24 +305,15 @@ The key used for this example is in {{int-key}}.
 
 Below is an example of a JWE using the JWE JSON Serialization and Integrated Encryption with HPKE:
 
-~~~
+~~~ json
 {
-  "ciphertext": "LabI8_KIPDbymUSbyVctj8AfISXQ07sMt1xQ1lrS-0h
-    eU2jjejpQIK75K1KXcvwn15E6Kil_tJ6LBcYCu02O1H8_aooJGuoLw1v
-    EzQn16h498YX9e2SA2IcVrJTkcCjL7YpF9fsAF3JEzGfsmmrpZPPVdxCn
-    7g8dkGRcyulnHrNvBu4BFtub-URtf-nYCFIJHZ4k-ul9fDddquicFzCxQ
-    onx66-ZX5nbj6azHG65tAZntd6VFkRgihdxTvIpvTS4gfulQeKyShbiw-
-    OCJNbzFdEnOKEMnsyqRjwG7iVrFEilFAMsvLJ14-lcuR5btIkUntIwlnsf
-    Ua2Ytk33znCfAFN0wYukdDvJe-V0nnNUFlOeLyYV0eEGisgC9dQQ1kFu3g",
-  "encrypted_key": "BAOlZ-VnbhQu4NOlTlDAVYwUJB-Q6YcWwnRNWK6Y
-    LSiHHlW4rN0qUzBJ3Rc2_y8nkasn8nUVGBzdq7OhdKKiLq4",
+  "ciphertext": "LabI8_KIPDbymUSbyVctj8AfISXQ07sMt1xQ1lrS-0heU2jjejpQIK75K1KXcvwn15E6Kil_tJ6LBcYCu02O1H8_aooJGuoLw1vEzQn16h498YX9e2SA2IcVrJTkcCjL7YpF9fsAF3JEzGfsmmrpZPPVdxCn7g8dkGRcyulnHrNvBu4BFtub-URtf-nYCFIJHZ4k-ul9fDddquicFzCxQonx66-ZX5nbj6azHG65tAZntd6VFkRgihdxTvIpvTS4gfulQeKyShbiw-OCJNbzFdEnOKEMnsyqRjwG7iVrFEilFAMsvLJ14-lcuR5btIkUntIwlnsfUa2Ytk33znCfAFN0wYukdDvJe-V0nnNUFlOeLyYV0eEGisgC9dQQ1kFu3g",
+  "encrypted_key": "BAOlZ-VnbhQu4NOlTlDAVYwUJB-Q6YcWwnRNWK6YLSiHHlW4rN0qUzBJ3Rc2_y8nkasn8nUVGBzdq7OhdKKiLq4",
   "aad": "VGhlIEZlbGxvd3NoaXAgb2YgdGhlIFJpbmc",
-  "protected": "eyJhbGciOiJIUEtFLTAiLCJraWQiOiJ5Q25mYm1ZTVpj
-    V3JLRHRfRGpOZWJSQ0IxdnhWb3F2NHVtSjRXSzhSWWprIn0"
+  "protected": "eyJhbGciOiJIUEtFLTAiLCJraWQiOiJ5Q25mYm1ZTVpjV3JLRHRfRGpOZWJSQ0IxdnhWb3F2NHVtSjRXSzhSWWprIn0"
 }
 ~~~
-
-Note: Line breaks are for display purposes only.
+{: post="fold69hardsmart2dry"}
 
 The key used for this example is in {{int-key}}.
 
@@ -424,28 +398,16 @@ This value is used as the HPKE "info" parameter when performing Key Encryption w
 The following JWE algorithms using HPKE are defined for use with
 Key Encryption as the Key Management Mode:
 
-~~~
-+-----------+------------------+-------------+------------------+
-| "alg"     | HPKE KEM         | HPKE KDF    | HPKE AEAD        |
-+-----------+------------------+-------------+------------------+
-| HPKE-0-KE | DHKEM(P-256,     | HKDF-SHA256 | AES-128-GCM      |
-|           |   HKDF-SHA256)   |             |                  |
-| HPKE-1-KE | DHKEM(P-384,     | HKDF-SHA384 | AES-256-GCM      |
-|           |   HKDF-SHA384)   |             |                  |
-| HPKE-2-KE | DHKEM(P-521,     | HKDF-SHA512 | AES-256-GCM      |
-|           |   HKDF-SHA512)   |             |                  |
-| HPKE-3-KE | DHKEM(X25519,    | HKDF-SHA256 | AES-128-GCM      |
-|           |   HKDF-SHA256)   |             |                  |
-| HPKE-4-KE | DHKEM(X25519,    | HKDF-SHA256 | ChaCha20Poly1305 |
-|           |   HKDF-SHA256)   |             |                  |
-| HPKE-5-KE | DHKEM(X448,      | HKDF-SHA512 | AES-256-GCM      |
-|           |   HKDF-SHA512)   |             |                  |
-| HPKE-6-KE | DHKEM(X448,      | HKDF-SHA512 | ChaCha20Poly1305 |
-|           |   HKDF-SHA512)   |             |                  |
-| HPKE-7-KE | DHKEM(P-256,     | HKDF-SHA256 | AES-256-GCM      |
-|           |   HKDF-SHA256)   |             |                  |
-+-----------+------------------+-------------+------------------+
-~~~
+| "alg"     | HPKE KEM                   | HPKE KDF    | HPKE AEAD        |
+| --------- | -------------------------- | ----------- | ---------------- |
+| HPKE-0-KE | DHKEM(P-256, HKDF-SHA256)  | HKDF-SHA256 | AES-128-GCM      |
+| HPKE-1-KE | DHKEM(P-384, HKDF-SHA384)  | HKDF-SHA384 | AES-256-GCM      |
+| HPKE-2-KE | DHKEM(P-521, HKDF-SHA512)  | HKDF-SHA512 | AES-256-GCM      |
+| HPKE-3-KE | DHKEM(X25519, HKDF-SHA256) | HKDF-SHA256 | AES-128-GCM      |
+| HPKE-4-KE | DHKEM(X25519, HKDF-SHA256) | HKDF-SHA256 | ChaCha20Poly1305 |
+| HPKE-5-KE | DHKEM(X448, HKDF-SHA512)   | HKDF-SHA512 | AES-256-GCM      |
+| HPKE-6-KE | DHKEM(X448, HKDF-SHA512)   | HKDF-SHA512 | ChaCha20Poly1305 |
+| HPKE-7-KE | DHKEM(P-256, HKDF-SHA256)  | HKDF-SHA256 | AES-256-GCM      |
 {: #ciphersuite-ke-algs title="Algorithms using HPKE for Key Encryption"}
 
 The HPKE KEM, KDF, and AEAD values are chosen from the IANA HPKE registry {{IANA.HPKE}}.
@@ -454,15 +416,9 @@ The HPKE KEM, KDF, and AEAD values are chosen from the IANA HPKE registry {{IANA
 
 Below is an example of a JWE using the General JSON Serialization and Key Encryption with HPKE:
 
-~~~
+~~~ json
 {
-  "ciphertext": "uF1XBbVZWhYm_pDbeJvI_fkuqFJiKd1WMP3O_BAGOP-L
-    kpTLE3Et2VQNcOpPAIBfyx8rUzshGqiOFOWzcoWZ3mIwYuDvvAW3-P1RC
-    S8Dtq70JRvahO5O8sAN1vzJg8_dyBPnwsQY6Cy3RhMD6sSSCjjSw0FYmm
-    x67IiI2zJ6Wr8z69k0f34ZTh43k4C-pTwaUSvjl2XI_YrUgdDVYmY_MJ5
-    vmlPTcceMaefP8Onz_fx5xOcGfnVBVz2gpMQPuQL8k5Rk5KJvPGfFfN6hr
-    gWkK_LDzi4lrfnIrvNsk3BCBeZPpc-n19-u7W4-GQxLjAlVyMHeGk5K4tU
-    6gHB8PnnQ4ND5ZTtyXrJWQW-Qr1iFev6g",
+  "ciphertext": "uF1XBbVZWhYm_pDbeJvI_fkuqFJiKd1WMP3O_BAGOP-LkpTLE3Et2VQNcOpPAIBfyx8rUzshGqiOFOWzcoWZ3mIwYuDvvAW3-P1RCS8Dtq70JRvahO5O8sAN1vzJg8_dyBPnwsQY6Cy3RhMD6sSSCjjSw0FYmmx67IiI2zJ6Wr8z69k0f34ZTh43k4C-pTwaUSvjl2XI_YrUgdDVYmY_MJ5vmlPTcceMaefP8Onz_fx5xOcGfnVBVz2gpMQPuQL8k5Rk5KJvPGfFfN6hrgWkK_LDzi4lrfnIrvNsk3BCBeZPpc-n19-u7W4-GQxLjAlVyMHeGk5K4tU6gHB8PnnQ4ND5ZTtyXrJWQW-Qr1iFev6g",
   "iv": "mLiHjYaQA42nPm1L",
   "recipients": [
     {
@@ -470,8 +426,7 @@ Below is an example of a JWE using the General JSON Serialization and Key Encryp
       "header": {
         "alg": "HPKE-0-KE",
         "kid": "9CfUPiGcAcTp7oXgVbDStw2FEjka-_KHU_i-X3XMCEA",
-        "ek": "BGWPWLoD5BUjFEDIjMS-yvtcCXBn5A-kuv2RjzUY_2hKUjg
-          ZINqtEy1aHZ8dWxAiyApV5JafG76W8O_yZzy5T54"
+        "ek": "BGWPWLoD5BUjFEDIjMS-yvtcCXBn5A-kuv2RjzUY_2hKUjgZINqtEy1aHZ8dWxAiyApV5JafG76W8O_yZzy5T54"
       }
     }
   ],
@@ -480,8 +435,7 @@ Below is an example of a JWE using the General JSON Serialization and Key Encryp
   "protected": "eyJlbmMiOiJBMTI4R0NNIn0"
 }
 ~~~
-
-Note: Line breaks are for display purposes only.
+{: post="fold69hardsmart2dry"}
 
 The key used for this example is in {{ke-key}}.
 
@@ -806,17 +760,13 @@ used with the JWE algorithms defined in this specification are as follows.
 The valid combinations of the
 "alg", "kty", and "crv" in the JWK are shown in {{ciphersuite-kty-crv}}.
 
-~~~
-+--------------------------------------+-------+--------+
 | "alg" values                         | "kty" | "crv"  |
-+--------------------------------------+-------+--------+
+| ------------------------------------ | ----- | ------ |
 | HPKE-0, HPKE-0-KE, HPKE-7, HPKE-7-KE | EC    | P-256  |
 | HPKE-1, HPKE-1-KE                    | EC    | P-384  |
 | HPKE-2, HPKE-2-KE                    | EC    | P-521  |
 | HPKE-3, HPKE-3-KE, HPKE-4, HPKE-4-KE | OKP   | X25519 |
 | HPKE-5, HPKE-5-KE, HPKE-6, HPKE-6-KE | OKP   | X448   |
-+--------------------------------------+-------+--------+
-~~~
 {: #ciphersuite-kty-crv title="JWK Types and Curves for JWE HPKE Ciphersuites"}
 
 ## JWK Representation of Key using JWE HPKE Ciphersuite
@@ -824,7 +774,7 @@ The valid combinations of the
 The example below is a JWK representation of a public and private key
 used with Integrated Encryption as the Key Management Mode:
 
-~~~
+~~~ json
 {
   "kty": "OKP",
   "crv": "X25519",
@@ -835,6 +785,7 @@ used with Integrated Encryption as the Key Management Mode:
   "use": "enc"
 }
 ~~~
+{: post="fold69hardsmart2dry"}
 
 # Security Considerations
 
@@ -1097,7 +1048,7 @@ This specification updates JSON Web Encryption (JWE) {{RFC7516}} as follows:
 This private key and its implied public key are used for
 the Integrated Encryption example in {{compact-example}} and {{flattened-example}}:
 
-~~~ text
+~~~ json
 {
   "kty": "EC",
   "use": "enc",
@@ -1109,13 +1060,14 @@ the Integrated Encryption example in {{compact-example}} and {{flattened-example
   "d": "g2DXtKapi2oN2zL_RCWX8D4bWURHCKN2-ZNGC05ZaR8"
 }
 ~~~
+{: post="fold69hardsmart2dry"}
 
 ## Key Encryption Key {#ke-key}
 
 This private key and its implied public key are used for
 the Key Encryption example in {{general-example}}:
 
-~~~ text
+~~~ json
 {
   "kty": "EC",
   "use": "enc",
@@ -1127,6 +1079,7 @@ the Key Encryption example in {{general-example}}:
   "d": "MeCnMF65SaRVZ11Gf1Weacx3H9SdzO7MtWcDXvHWNv8"
 }
 ~~~
+{: post="fold69hardsmart2dry"}
 
 # Acknowledgments
 {: numbered="false"}


### PR DESCRIPTION
Use RFC8792 single backslash strategy and markdown tables which kramdown-rfc transforms and wraps nicely.

Using RFC8792 has the benefit of having a copy button in the new rfc-editor website e.g. https://www.rfc-editor.org/info/rfc8792/ thanks to https://github.com/ietf-tools/red/pull/411

[draft-ietf-jose-hpke-encrypt.html](https://github.com/user-attachments/files/28842283/draft-ietf-jose-hpke-encrypt.html)
[draft-ietf-jose-hpke-encrypt.txt](https://github.com/user-attachments/files/28842284/draft-ietf-jose-hpke-encrypt.txt)
